### PR TITLE
解决 Audio data must be floating-point

### DIFF
--- a/funclip/trans_utils.py
+++ b/funclip/trans_utils.py
@@ -79,5 +79,27 @@ def load_state(output_dir):
             line = fin.read()
             state['sd_sentences'] = eval(line)
     return state
-        
+
+import numpy as np       
+def convert_pcm_to_float(data):
+    if data.dtype == np.float64:
+        return data
+    elif data.dtype == np.float32:
+        return data.astype(np.float64)
+    elif data.dtype == np.int16:
+        bit_depth = 16
+    elif data.dtype == np.int32:
+        bit_depth = 32
+    elif data.dtype == np.int8:
+        bit_depth = 8
+    else:
+        raise ValueError("Unsupported audio data type")
+
+    # Now handle the integer types
+    max_int_value = float(2 ** (bit_depth - 1))
+    if bit_depth == 8:
+        data = data - 128
+    return (data.astype(np.float64) / max_int_value)
+
+
     

--- a/funclip/videoclipper.py
+++ b/funclip/videoclipper.py
@@ -12,7 +12,7 @@ from moviepy.editor import *
 from moviepy.video.tools.subtitles import SubtitlesClip
 from subtitle_utils import generate_srt, generate_srt_clip
 from argparse_tools import ArgumentParser, get_commandline_args
-from trans_utils import pre_proc, proc, write_state, load_state, proc_spk
+from trans_utils import pre_proc, proc, write_state, load_state, proc_spk, convert_pcm_to_float
 
 
 class VideoClipper():
@@ -25,6 +25,10 @@ class VideoClipper():
         if state is None:
             state = {}
         sr, data = audio_input
+
+        # Convert to float64 consistently (includes data type checking)
+        data = convert_pcm_to_float(data)
+
         # assert sr == 16000, "16kHz sample rate required, {} given.".format(sr)
         if sr != 16000: # resample with librosa
             data = librosa.resample(data, orig_sr=sr, target_sr=16000)
@@ -32,7 +36,6 @@ class VideoClipper():
             logging.warning("Input wav shape: {}, only first channel reserved.").format(data.shape)
             data = data[:,0]
         state['audio_input'] = (sr, data)
-        data = data.astype(np.float64)
         if sd_switch == 'yes':
             rec_result = self.funasr_model.generate(data, return_raw_text=True, is_final=True, hotword=hotwords)
             res_srt = generate_srt(rec_result[0]['sentence_info'])


### PR DESCRIPTION
在魔塔在线体验和本地部署之后，上传wav音频，均遇到如下报错：
  File "funclip/launch.py", line 21, in audio_recog
    return audio_clipper.recog(audio_input, sd_switch, hotwords=hotwords)
  File "/root/FunClip/FunClip/funclip/videoclipper.py", line 30, in recog
    data = librosa.resample(data, orig_sr=sr, target_sr=16000)
  File "/root/miniconda3/envs/funclip/lib/python3.8/site-packages/librosa/core/audio.py", line 627, in resample
    util.valid_audio(y, mono=False)
  File "/root/miniconda3/envs/funclip/lib/python3.8/site-packages/librosa/util/utils.py", line 298, in valid_audio
    raise ParameterError("Audio data must be floating-point")
librosa.util.exceptions.ParameterError: Audio data must be floating-point
这段报错，主要是librosa 在处理音频数据时期望浮点型数据，但接收到的可能是整型数据（例如int16）。librosa 处理音频时，音频数据需要是浮点数格式，通常范围在 -1.0 到 1.0，所以增加了convert_pcm_to_float 函数将音频转成浮点数