### PR TITLE
Fix double application of audio/video offset for concatenated segments

### DIFF
--- a/funclip/videoclipper.py
+++ b/funclip/videoclipper.py
@@ -128,7 +128,7 @@ class VideoClipper():
                 start = min(max(0, start+start_ost*16), len(data))
                 end = min(max(0, end+end_ost*16), len(data))
                 start_end_info += ", from {} to {}".format(start, end)
-                res_audio = np.concatenate([res_audio, data[start+start_ost*16:end+end_ost*16]], -1)
+                res_audio = np.concatenate([res_audio, data[start:end]], -1)
                 srt_clip, _, srt_index = generate_srt_clip(sentences, start/16000.0, end/16000.0, begin_index=srt_index-1)
                 clip_srt += srt_clip
         if len(ts):
@@ -238,7 +238,7 @@ class VideoClipper():
                 subtitles = SubtitlesClip(subs, generator)
                 video_clip = CompositeVideoClip([video_clip, subtitles.set_pos(('center','bottom'))])
             concate_clip = [video_clip]
-            time_acc_ost += end+end_ost/1000.0 - (start+start_ost/1000.0)
+            time_acc_ost += end - start
             for _ts in ts[1:]:
                 start, end = _ts[0] / 16000, _ts[1] / 16000
                 srt_clip, subs, srt_index = generate_srt_clip(sentences, start, end, begin_index=srt_index-1, time_acc_ost=time_acc_ost)
@@ -258,7 +258,7 @@ class VideoClipper():
                     _video_clip = CompositeVideoClip([_video_clip, subtitles.set_pos(('center','bottom'))])
                     # _video_clip.write_videofile("debug.mp4", audio_codec="aac")
                 concate_clip.append(copy.copy(_video_clip))
-                time_acc_ost += end+end_ost/1000.0 - (start+start_ost/1000.0)
+                time_acc_ost += end - start
             message = "{} periods found in the audio: ".format(len(ts)) + start_end_info
             logging.warning("Concating...")
             if len(concate_clip) > 1:


### PR DESCRIPTION
## Summary

When clipping multiple segments (concatenated clips), the audio and video offsets (`start_ost`/`end_ost`) are applied **twice** — once when computing `start`/`end`, and again when slicing the data or computing `time_acc_ost`. This causes incorrect clip boundaries for any multi-segment operation.

**In `clip()`:** `start` and `end` already include the offsets after the clamping step (lines 128–129), but the data slice for subsequent segments was `data[start+start_ost*16:end+end_ost*16]`, applying the offsets a second time. Fixed to use `data[start:end]`.

**In `video_clip()`:** `start` and `end` already incorporate `start_ost/1000.0` and `end_ost/1000.0`, but `time_acc_ost` was calculated as `end+end_ost/1000.0 - (start+start_ost/1000.0)`, double-counting the offsets. Fixed to use `end - start`.

Note that the first segment in both methods was already handled correctly — the bug only affected the 2nd, 3rd, ... segments when multiple periods are matched and concatenated.

Fixes #129
Fixes #144

## Test plan

- [ ] Clip a single segment with non-zero `start_ost`/`end_ost` — should behave identically to before (no change for single segments)
- [ ] Clip multiple segments with non-zero offsets — boundaries should now match the expected offset-adjusted positions instead of double-shifting
- [ ] Verify subtitle timing (`time_acc_ost`) aligns correctly with concatenated video clips