### PR TITLE
docs: make CLI quickstart runnable (fetch the example video)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ Follow the guide below to explore LLM based clipping:
 
 FunClip supports you to recognize and clip with commands:
 ```shell
+# download the example video used in the commands below
+mkdir -p examples
+wget "https://huggingface.co/spaces/R1ckShi/FunClip/resolve/main/examples/2022%E4%BA%91%E6%A0%96%E5%A4%A7%E4%BC%9A_%E7%89%87%E6%AE%B5.mp4" -O "examples/2022云栖大会_片段.mp4"
+
 # step1: Recognize
 python funclip/videoclipper.py --stage 1 \
                        --file examples/2022云栖大会_片段.mp4 \

--- a/README_zh.md
+++ b/README_zh.md
@@ -127,6 +127,10 @@ python funclip/launch.py
 
 ### B.通过命令行调用使用FunClip的相关功能
 ```shell
+# 下载下面命令用到的示例视频
+mkdir -p examples
+wget "https://huggingface.co/spaces/R1ckShi/FunClip/resolve/main/examples/2022%E4%BA%91%E6%A0%96%E5%A4%A7%E4%BC%9A_%E7%89%87%E6%AE%B5.mp4" -O "examples/2022云栖大会_片段.mp4"
+
 # 步骤一：识别
 python funclip/videoclipper.py --stage 1 \
                        --file examples/2022云栖大会_片段.mp4 \


### PR DESCRIPTION
## Problem

The command-line quickstart references `examples/2022云栖大会_片段.mp4`, but the repo ships **no `examples/` directory** (it's not in the repo tree). So a new user who clones FunClip and runs the documented workflow:

```shell
python funclip/videoclipper.py --stage 1 --file examples/2022云栖大会_片段.mp4 --output_dir ./output
```

hits a file-not-found error. The stage-2 example is also coupled to this video (its `--dest_text` matches the video's speech), so just swapping in a placeholder wouldn't keep the example coherent.

## Fix

Add a `wget` step that downloads that exact example video from the official FunClip Space (`R1ckShi/FunClip`), so the existing stage-1/stage-2 commands run as-is. Applied to both `README.md` and `README_zh.md`.

## Verification

Verified the URL downloads the full, valid video:

```
examples/2022云栖大会_片段.mp4: ISO Media, Apple QuickTime movie   (36,077,615 bytes)
```

Docs-only change; the videoclipper commands themselves are unchanged.
