### PR TITLE
docs: update FunClip clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center"> <img src="docs/images/interface.jpg" width=444/></p>
 
 <p align="center" class="trendshift">
-<a href="https://trendshift.io/repositories/10126" target="_blank"><img src="https://trendshift.io/api/badge/repositories/10126" alt="alibaba-damo-academy%2FFunClip | Trendshift" style="width: 250px; height: 55px;" width="300" height="55"/></a>
+<a href="https://trendshift.io/repositories/10126" target="_blank"><img src="https://trendshift.io/api/badge/repositories/10126" alt="modelscope%2FFunClip | Trendshift" style="width: 250px; height: 55px;" width="300" height="55"/></a>
 </p>
 
 <div align="center">  
@@ -68,7 +68,7 @@
 FunClip basic functions rely on a python environment only.
 ```shell
 # clone funclip repo
-git clone https://github.com/alibaba-damo-academy/FunClip.git
+git clone https://github.com/modelscope/FunClip.git
 cd FunClip
 # install Python requirments
 pip install -r ./requirements.txt

--- a/README_zh.md
+++ b/README_zh.md
@@ -8,7 +8,7 @@
 <p align="center"> <img src="docs/images/interface.jpg" width=444/></p>
 
 <p align="center" class="trendshift">
-<a href="https://trendshift.io/repositories/10126" target="_blank"><img src="https://trendshift.io/api/badge/repositories/10126" alt="alibaba-damo-academy%2FFunClip | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+<a href="https://trendshift.io/repositories/10126" target="_blank"><img src="https://trendshift.io/api/badge/repositories/10126" alt="modelscope%2FFunClip | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </p>
 
 <div align="center">  
@@ -69,7 +69,7 @@
 FunClip的运行仅依赖于一个Python环境，若您是一个小白开发者，可以先了解下如何使用Python，pip等~
 ```shell
 # 克隆funclip仓库
-git clone https://github.com/alibaba-damo-academy/FunClip.git
+git clone https://github.com/modelscope/FunClip.git
 cd FunClip
 # 安装相关Python依赖
 pip install -r ./requirements.txt


### PR DESCRIPTION
## Summary

- Updates the English and Chinese README clone commands from the old `alibaba-damo-academy/FunClip` path to `modelscope/FunClip`.
- Updates the Trendshift badge alt text so it no longer advertises the old organization path.

## Why

The install path is one of the highest-intent conversion points in the README. Sending new users to the current repository path avoids confusion and keeps copy-paste setup aligned with the active project.

## Validation

- `git diff --check`
- Confirmed no remaining `alibaba-damo-academy/FunClip` or `alibaba-damo-academy%2FFunClip` references in `README.md` / `README_zh.md`
- Confirmed the new `git clone https://github.com/modelscope/FunClip.git` command appears in both READMEs
