### PR TITLE
docs: link official FunClip Space

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </h4>
 </div>
 
-**FunClip** is a fully open-source, locally deployed automated video clipping tool. It leverages Alibaba TONGYI speech lab's open-source [FunASR](https://github.com/modelscope/FunASR) Paraformer series models to perform speech recognition on videos. Then, users can freely choose text segments or speakers from the recognition results and click the clip button to obtain the video clip corresponding to the selected segments (Quick Experience [Modelscope⭐](https://modelscope.cn/studios/iic/funasr_app_clipvideo/summary) [HuggingFace🤗](https://huggingface.co/spaces/R1ckShi/FunClip)).
+**FunClip** is a fully open-source, locally deployed automated video clipping tool. It leverages Alibaba TONGYI speech lab's open-source [FunASR](https://github.com/modelscope/FunASR) Paraformer series models to perform speech recognition on videos. Then, users can freely choose text segments or speakers from the recognition results and click the clip button to obtain the video clip corresponding to the selected segments (Quick Experience [Modelscope⭐](https://modelscope.cn/studios/iic/funasr_app_clipvideo/summary) [HuggingFace🤗](https://huggingface.co/spaces/FunAudioLLM/FunClip)).
 
 ## Highlights🎨
 
@@ -145,7 +145,7 @@ Besides the transcript-based LLMs above, FunClip can optionally use [TwelveLabs]
 
 [FunClip@Modelscope Space⭐](https://modelscope.cn/studios/iic/funasr_app_clipvideo/summary)
 
-[FunClip@HuggingFace Space🤗](https://huggingface.co/spaces/R1ckShi/FunClip)
+[FunClip@HuggingFace Space🤗](https://huggingface.co/spaces/FunAudioLLM/FunClip)
 
 ### C. Use FunClip in command line
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -20,7 +20,7 @@
 </h4>
 </div>
 
-**FunClip**是一款完全开源、本地部署的自动化视频剪辑工具，通过调用阿里巴巴通义实验室开源的[FunASR](https://github.com/modelscope/FunASR) Paraformer系列模型进行视频的语音识别，随后用户可以自由选择识别结果中的文本片段或说话人，点击裁剪按钮即可获取对应片段的视频（快速体验 [Modelscope⭐](https://modelscope.cn/studios/iic/funasr_app_clipvideo/summary)  [HuggingFace🤗](https://huggingface.co/spaces/R1ckShi/FunClip)）。
+**FunClip**是一款完全开源、本地部署的自动化视频剪辑工具，通过调用阿里巴巴通义实验室开源的[FunASR](https://github.com/modelscope/FunASR) Paraformer系列模型进行视频的语音识别，随后用户可以自由选择识别结果中的文本片段或说话人，点击裁剪按钮即可获取对应片段的视频（快速体验 [Modelscope⭐](https://modelscope.cn/studios/iic/funasr_app_clipvideo/summary)  [HuggingFace🤗](https://huggingface.co/spaces/FunAudioLLM/FunClip)）。
 
 ## 热点&特性🎨
 
@@ -162,7 +162,7 @@ python funclip/videoclipper.py --stage 2 \
 
 [FunClip@Modelscope创空间⭐](https://modelscope.cn/studios/iic/funasr_app_clipvideo/summary)
 
-[FunClip@HuggingFace Space🤗](https://huggingface.co/spaces/R1ckShi/FunClip)
+[FunClip@HuggingFace Space🤗](https://huggingface.co/spaces/FunAudioLLM/FunClip)
 
 
 <a name="社区交流"></a>


### PR DESCRIPTION
## Summary

- point the English and Chinese README quick-experience links to the official `FunAudioLLM/FunClip` Hugging Face Space;
- keep the legacy Space URLs used only for example video downloads unchanged.

## Validation

- README regression assertion: official Space appears twice in each README and the legacy Space remains only once per README for the example asset;
- `https://huggingface.co/spaces/FunAudioLLM/FunClip` returned HTTP 200;
- `https://funaudiollm-funclip.hf.space/` returned HTTP 200;
- `git diff --check`.
