### PR TITLE
fix: normalize Pegasus timestamp ranges

### DIFF
--- a/funclip/llm/twelvelabs_api.py
+++ b/funclip/llm/twelvelabs_api.py
@@ -1,6 +1,11 @@
 import os
 import time
 import logging
+import re
+from decimal import Decimal, ROUND_HALF_UP
+
+
+_PEGASUS_SECONDS_RANGE_RE = re.compile(r"\[(\d+(?:\.\d+)?)\s*-\s*(\d+(?:\.\d+)?)\]")
 
 
 # Default instruction asking Pegasus to return segments in the same
@@ -15,6 +20,42 @@ PEGASUS_SYSTEM_PROMPT = (
     "where start_time and end_time are seconds from the start of the video "
     "(e.g. 12.5), the connector is '-', and description is a short summary."
 )
+
+
+def _seconds_to_milliseconds(seconds):
+    return int(
+        (Decimal(seconds) * 1000).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+    )
+
+
+def _format_srt_timestamp(milliseconds):
+    hours, remainder = divmod(milliseconds, 60 * 60 * 1000)
+    minutes, remainder = divmod(remainder, 60 * 1000)
+    seconds, milliseconds = divmod(remainder, 1000)
+    return "{:02d}:{:02d}:{:02d},{:03d}".format(
+        hours, minutes, seconds, milliseconds
+    )
+
+
+def _normalize_pegasus_timestamps(text):
+    """Convert Pegasus decimal-second ranges to FunClip's SRT range format."""
+    if not isinstance(text, str):
+        return text
+
+    def replace_range(match):
+        start_millis = _seconds_to_milliseconds(match.group(1))
+        end_millis = _seconds_to_milliseconds(match.group(2))
+        if end_millis <= start_millis or end_millis >= 100 * 60 * 60 * 1000:
+            logging.warning(
+                "Ignoring invalid Pegasus timestamp range: %s", match.group(0)
+            )
+            return match.group(0)
+        return "[{}-{}]".format(
+            _format_srt_timestamp(start_millis),
+            _format_srt_timestamp(end_millis),
+        )
+
+    return _PEGASUS_SECONDS_RANGE_RE.sub(replace_range, text)
 
 
 def _resolve_video_context(client, video):
@@ -80,7 +121,7 @@ def call_twelvelabs_pegasus(apikey,
         max_tokens=max_tokens,
     )
     logging.info("TwelveLabs Pegasus inference done.")
-    return response.data
+    return _normalize_pegasus_timestamps(response.data)
 
 
 if __name__ == '__main__':

--- a/tests/test_twelvelabs_pegasus.py
+++ b/tests/test_twelvelabs_pegasus.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "funclip"))
@@ -11,6 +12,7 @@ from llm.twelvelabs_api import (
     call_twelvelabs_pegasus,
     PEGASUS_SYSTEM_PROMPT,
 )
+from utils.trans_utils import extract_timestamps
 
 
 class TestResolveVideoContext(unittest.TestCase):
@@ -28,6 +30,57 @@ class TestResolveVideoContext(unittest.TestCase):
 
     def test_default_prompt_requests_parseable_segment_format(self):
         self.assertIn("[start_time-end_time]", PEGASUS_SYSTEM_PROMPT)
+
+
+class TestPegasusTimestampNormalization(unittest.TestCase):
+    def _call_with_response(self, response_text):
+        with patch("twelvelabs.TwelveLabs") as client_class, patch(
+            "llm.twelvelabs_api._resolve_video_context", return_value=object()
+        ):
+            client_class.return_value.analyze.return_value.data = response_text
+            return call_twelvelabs_pegasus(
+                "test-key", "https://example.com/clip.mp4"
+            )
+
+    def test_decimal_and_integer_ranges_feed_existing_parser(self):
+        response = (
+            "1. [12.5-15.0] first highlight\n"
+            "2. [120 - 135] second highlight"
+        )
+
+        normalized = self._call_with_response(response)
+
+        self.assertEqual(
+            normalized,
+            "1. [00:00:12,500-00:00:15,000] first highlight\n"
+            "2. [00:02:00,000-00:02:15,000] second highlight",
+        )
+        self.assertEqual(
+            extract_timestamps(normalized), [[12500, 15000], [120000, 135000]]
+        )
+
+    def test_existing_srt_range_is_unchanged(self):
+        response = "1. [00:00:12,500-00:00:15,000] existing highlight"
+
+        normalized = self._call_with_response(response)
+
+        self.assertEqual(normalized, response)
+        self.assertEqual(extract_timestamps(normalized), [[12500, 15000]])
+
+    def test_invalid_ranges_do_not_create_clips(self):
+        response = (
+            "1. [15-12.5] reversed\n"
+            "2. [8-8] empty\n"
+            "3. [not-a-time] malformed\n"
+            "4. [1.25-2.5] valid"
+        )
+
+        normalized = self._call_with_response(response)
+
+        self.assertIn("[15-12.5]", normalized)
+        self.assertIn("[8-8]", normalized)
+        self.assertIn("[not-a-time]", normalized)
+        self.assertEqual(extract_timestamps(normalized), [[1250, 2500]])
 
 
 @unittest.skipUnless(


### PR DESCRIPTION
## Summary

- normalize Pegasus decimal-second ranges into the SRT format consumed by FunClip
- preserve existing SRT-formatted LLM responses unchanged
- leave malformed, reversed, zero-length, and unsupported ranges unparsed
- cover decimal, integer, multiple, existing SRT, and invalid ranges through the production inference-to-parser path

## Verification

- python -m pytest -q tests
- 10 passed, 1 skipped
- python -m compileall -q funclip tests
- git diff --check

Fixes #171
