### PR TITLE
docs: clarify source and model licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ FunClip is part of the **FunAudioLLM** family:
 📚FunASR Paper: <a href="https://arxiv.org/abs/2305.11013"><img src="https://img.shields.io/badge/Arxiv-2305.11013-orange"></a> 
 📚SeACo-Paraformer Paper: <a href="https://arxiv.org/abs/2308.03266"><img src="https://img.shields.io/badge/Arxiv-2308.03266-orange"></a>
 
+## License
+
+- FunClip source code is licensed under the [MIT License](./LICENSE).
+- Model weights are downloaded separately and are governed by the terms on their model pages. The default [Paraformer-Large](https://modelscope.cn/models/iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary), [SeACo-Paraformer](https://modelscope.cn/models/iic/speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary), and [CAM++](https://modelscope.cn/models/iic/speech_campplus_sv_zh-cn_16k-common/summary) pages currently list Apache License 2.0; check the applicable model page before redistribution.
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=modelscope/FunClip&type=Date)](https://star-history.com/#modelscope/FunClip&Date)

--- a/README_zh.md
+++ b/README_zh.md
@@ -164,6 +164,11 @@ python funclip/videoclipper.py --stage 2 \
 
 [FunClip@HuggingFace Space🤗](https://huggingface.co/spaces/FunAudioLLM/FunClip)
 
+## 许可证
+
+- FunClip 源码采用 [MIT License](./LICENSE)。
+- 模型权重单独下载，并遵循各模型页面标注的条款。默认使用的 [Paraformer-Large](https://modelscope.cn/models/iic/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary)、[SeACo-Paraformer](https://modelscope.cn/models/iic/speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary) 与 [CAM++](https://modelscope.cn/models/iic/speech_campplus_sv_zh-cn_16k-common/summary) 页面目前均标注 Apache License 2.0；重新分发前请核对适用的模型页面。
+
 
 <a name="社区交流"></a>
 ## 社区交流🍟


### PR DESCRIPTION
## Summary
- document the MIT license for FunClip source code
- clarify that downloaded model weights retain their model-page terms
- link the three default model pages in both English and Chinese READMEs

## Verification
- `git diff --check`
- all new links returned HTTP 200
- ModelScope API currently reports Apache License 2.0 for Paraformer-Large, SeACo-Paraformer, and CAM++