### PR TITLE
docs: require current FunASR for model modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ cd FunClip
 pip install -r ./requirements.txt
 ```
 
+FunClip's Fun-ASR-Nano, SenseVoice, and subtitle compatibility paths require `funasr>=1.3.19`. If you installed FunClip before this requirement was updated, run `pip install -U "funasr>=1.3.19"` before starting the Gradio service.
+
 ### imagemagick install (Optional)
 
 If you want to clip video file with embedded subtitles

--- a/README_zh.md
+++ b/README_zh.md
@@ -75,6 +75,8 @@ cd FunClip
 pip install -r ./requirements.txt
 ```
 
+FunClip 的 Fun-ASR-Nano、SenseVoice 与字幕兼容路径需要 `funasr>=1.3.19`。如果你之前已经安装过 FunClip，请先执行 `pip install -U "funasr>=1.3.19"`，再启动 Gradio 服务。
+
 ### 安装imagemagick（可选）
 
 1. 如果你希望使用自动生成字幕的视频裁剪功能，需要安装imagemagick

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 librosa
 soundfile
 scikit-learn>=1.3.2
-funasr>=1.1.2
+funasr>=1.3.19
 transformers>=4.32.0,<5.0
 huggingface_hub>=0.19.3,<1.0
 moviepy==1.0.3

--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_funasr_minimum_version_matches_current_model_paths():
+    requirements = (ROOT / "requirements.txt").read_text()
+    assert "funasr>=1.3.19" in requirements
+    assert "funasr>=1.1.2" not in requirements
+
+
+def test_readmes_explain_upgrade_for_existing_installs():
+    for readme in ["README.md", "README_zh.md"]:
+        text = (ROOT / readme).read_text()
+        assert 'pip install -U "funasr>=1.3.19"' in text


### PR DESCRIPTION
## Summary
- raise the FunASR dependency floor to funasr>=1.3.19
- explain the upgrade command for existing FunClip installs in English and Chinese READMEs
- add a regression test so the minimum version and upgrade note do not drift backward

## Why
FunClip now advertises Fun-ASR-Nano and SenseVoice model modes. Keeping requirements at funasr>=1.1.2 can leave new users with an old FunASR install that does not match the current model, subtitle, and compatibility paths.

## Validation
- python3 -m pytest tests/test_funasr_requirement.py -q
- python3 -m py_compile funclip/launch.py tests/test_funasr_requirement.py tests/test_model_selection.py
- git diff --check
- PyPI JSON confirms funasr 1.3.19 exists
- curl link checks for PyPI funasr 1.3.19, Fun-ASR-Nano, and SenseVoiceSmall returned 200

Note: tests/test_model_selection.py collection requires gradio in this local environment; the focused dependency regression test passed, and launch.py was compiled without importing runtime dependencies.