### PR TITLE
Add Atlas Cloud LLM option

### DIFF
--- a/funclip/launch.py
+++ b/funclip/launch.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
             )
         
     def llm_inference(system_content, user_content, srt_text, model, apikey, video_input=None):
-        SUPPORT_LLM_PREFIX = ['litellm', 'qwen', 'gpt', 'g4f', 'moonshot', 'deepseek', 'pegasus']
+        SUPPORT_LLM_PREFIX = ['litellm', 'qwen', 'gpt', 'g4f', 'moonshot', 'deepseek', 'atlascloud', 'pegasus']
         if model.startswith('litellm/'):
             return litellm_call(apikey, model, user_content+'\n'+srt_text, system_content)
         if model.startswith('pegasus'):
@@ -178,7 +178,7 @@ if __name__ == "__main__":
             return call_twelvelabs_pegasus(apikey, video_input, model=model, prompt=system_content)
         if model.startswith('qwen'):
             return call_qwen_model(apikey, model, user_content+'\n'+srt_text, system_content)
-        if model.startswith('gpt') or model.startswith('moonshot') or model.startswith('deepseek'):
+        if model.startswith('gpt') or model.startswith('moonshot') or model.startswith('deepseek') or model.startswith('atlascloud/'):
             return openai_call(apikey, model, system_content, user_content+'\n'+srt_text)
         elif model.startswith('g4f'):
             model = "-".join(model.split('-')[1:])
@@ -280,6 +280,8 @@ if __name__ == "__main__":
                                              "g4f-gpt-3.5-turbo",
                                              "litellm/openai/gpt-4o",
                                              "litellm/anthropic/claude-sonnet-4-6",
+                                             "atlascloud/qwen/qwen3.5-flash",
+                                             "atlascloud/deepseek-ai/deepseek-v4-pro",
                                              "pegasus1.5"],
                                     value="deepseek-chat",
                                     label="LLM Model Name",

--- a/funclip/llm/openai_api.py
+++ b/funclip/llm/openai_api.py
@@ -2,6 +2,31 @@ import os
 import logging
 from openai import OpenAI
 
+ATLASCLOUD_API_BASE = "https://api.atlascloud.ai/v1"
+ATLASCLOUD_MODEL_PREFIX = "atlascloud/"
+
+
+def _resolve_model_config(model):
+    base_url = None
+    api_key_env = None
+
+    if model.startswith(ATLASCLOUD_MODEL_PREFIX):
+        model = model[len(ATLASCLOUD_MODEL_PREFIX):]
+        if not model:
+            raise ValueError(
+                "Model name is empty after stripping atlascloud/ prefix"
+            )
+        base_url = os.environ.get("ATLASCLOUD_API_BASE", ATLASCLOUD_API_BASE).strip()
+        if not base_url:
+            base_url = ATLASCLOUD_API_BASE
+        api_key_env = "ATLASCLOUD_API_KEY"
+    elif model.startswith("deepseek"):
+        base_url = "https://api.deepseek.com"
+    elif model.startswith("gpt-3.5-turbo"):
+        base_url = "https://api.moonshot.cn/v1"
+
+    return model, base_url, api_key_env
+
 
 if __name__ == '__main__':
     from llm.demo_prompt import demo_prompt
@@ -26,11 +51,10 @@ def openai_call(apikey,
                 model="gpt-3.5-turbo", 
                 user_content="如何做西红柿炖牛腩？", 
                 system_content=None):
-    base_url = None
-    if model.startswith("deepseek"):
-        base_url = "https://api.deepseek.com"
-    elif model.startswith("gpt-3.5-turbo"):
-        base_url = "https://api.moonshot.cn/v1"
+    model, base_url, api_key_env = _resolve_model_config(model)
+    if not apikey and api_key_env:
+        apikey = os.environ.get(api_key_env)
+
     client = OpenAI(
         # This is the default and can be omitted
         api_key=apikey,

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -1,0 +1,59 @@
+"""Tests for OpenAI-compatible LLM routing."""
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from funclip.llm.openai_api import ATLASCLOUD_API_BASE, openai_call
+
+
+def _mock_completion(content="ok"):
+    completion = MagicMock()
+    completion.choices = [MagicMock()]
+    completion.choices[0].message.content = content
+    return completion
+
+
+class TestOpenAICompatibleRouting(unittest.TestCase):
+    def test_atlascloud_prefix_uses_atlas_base_url(self):
+        client = MagicMock()
+        client.chat.completions.create.return_value = _mock_completion("clip plan")
+
+        with patch("funclip.llm.openai_api.OpenAI", return_value=client) as openai_cls:
+            result = openai_call(
+                "atlas-key",
+                "atlascloud/qwen/qwen3.5-flash",
+                "subtitle text",
+                "find highlights",
+            )
+
+        self.assertEqual(result, "clip plan")
+        openai_cls.assert_called_once_with(
+            api_key="atlas-key",
+            base_url=ATLASCLOUD_API_BASE,
+        )
+        call_kwargs = client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs["model"], "qwen/qwen3.5-flash")
+
+    def test_atlascloud_api_key_falls_back_to_env(self):
+        client = MagicMock()
+        client.chat.completions.create.return_value = _mock_completion()
+
+        with patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "env-atlas-key"}, clear=False):
+            with patch("funclip.llm.openai_api.OpenAI", return_value=client) as openai_cls:
+                openai_call("", "atlascloud/deepseek-ai/deepseek-v4-pro", "text")
+
+        openai_cls.assert_called_once_with(
+            api_key="env-atlas-key",
+            base_url=ATLASCLOUD_API_BASE,
+        )
+        call_kwargs = client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs["model"], "deepseek-ai/deepseek-v4-pro")
+
+    def test_empty_atlascloud_model_raises(self):
+        with self.assertRaises(ValueError):
+            openai_call("key", "atlascloud/", "text")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `atlascloud/` OpenAI-compatible routing to the existing LLM clipping backend
- prefill Atlas Cloud model choices for `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`
- add focused tests for Atlas Cloud base URL routing, model ID normalization, and `ATLASCLOUD_API_KEY` fallback

## Validation
- `python3 -m pytest tests/test_openai_api.py -q`
- `python3 -m py_compile funclip/llm/openai_api.py funclip/launch.py tests/test_openai_api.py`
- `git diff --check`
- confirmed the Atlas Cloud live model catalog includes `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

Note: broader existing tests that import optional packages (`litellm`, `twelvelabs`, `gradio`, `librosa`) could not run in this local environment because those dependencies are not installed.
