### PR TITLE
docs: require FunASR 1.3.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ cd FunClip
 pip install -r ./requirements.txt
 ```
 
-FunClip's Fun-ASR-Nano, SenseVoice, and subtitle compatibility paths require `funasr>=1.3.23`. If you installed FunClip before this requirement was updated, run `pip install -U "funasr>=1.3.23"` before starting the Gradio service.
+FunClip's Fun-ASR-Nano, SenseVoice, and subtitle compatibility paths require `funasr>=1.3.24`. If you installed FunClip before this requirement was updated, run `pip install -U "funasr>=1.3.24"` before starting the Gradio service.
 
 ### imagemagick install (Optional)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -75,7 +75,7 @@ cd FunClip
 pip install -r ./requirements.txt
 ```
 
-FunClip 的 Fun-ASR-Nano、SenseVoice 与字幕兼容路径需要 `funasr>=1.3.23`。如果你之前已经安装过 FunClip，请先执行 `pip install -U "funasr>=1.3.23"`，再启动 Gradio 服务。
+FunClip 的 Fun-ASR-Nano、SenseVoice 与字幕兼容路径需要 `funasr>=1.3.24`。如果你之前已经安装过 FunClip，请先执行 `pip install -U "funasr>=1.3.24"`，再启动 Gradio 服务。
 
 ### 安装imagemagick（可选）
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 librosa
 soundfile
 scikit-learn>=1.3.2
-funasr>=1.3.23
+funasr>=1.3.24
 transformers>=4.32.0,<5.0
 huggingface_hub>=0.19.3,<1.0
 moviepy==1.0.3

--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -6,14 +6,16 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_funasr_minimum_version_matches_current_model_paths():
     requirements = (ROOT / "requirements.txt").read_text()
-    assert "funasr>=1.3.23" in requirements
+    assert "funasr>=1.3.24" in requirements
     assert "funasr>=1.1.2" not in requirements
+    assert "funasr>=1.3.23" not in requirements
 
 
 def test_readmes_explain_upgrade_for_existing_installs():
     for readme in ["README.md", "README_zh.md"]:
         text = (ROOT / readme).read_text()
-        assert 'pip install -U "funasr>=1.3.23"' in text
+        assert 'pip install -U "funasr>=1.3.24"' in text
+        assert "funasr>=1.3.23" not in text
 
 
 def test_english_readme_avoids_visible_typo_regressions():


### PR DESCRIPTION
## Summary
- update FunClip's FunASR install floor to the newly published `funasr>=1.3.24`
- refresh English and Chinese README upgrade guidance
- extend the regression test to reject the old 1.3.23 floor

## Tests
- python3 -m pytest -q tests/test_funasr_requirement.py
- git diff --check
