### PR TITLE
docs: require FunASR 1.3.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ cd FunClip
 pip install -r ./requirements.txt
 ```
 
-FunClip's Fun-ASR-Nano, SenseVoice, and subtitle compatibility paths require `funasr>=1.3.25`. If you installed FunClip before this requirement was updated, run `pip install -U "funasr>=1.3.25"` before starting the Gradio service.
+FunClip's Fun-ASR-Nano, SenseVoice, and subtitle compatibility paths require `funasr>=1.3.26`. If you installed FunClip before this requirement was updated, run `pip install -U "funasr>=1.3.26"` before starting the Gradio service.
 
 ### imagemagick install (Optional)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -75,7 +75,7 @@ cd FunClip
 pip install -r ./requirements.txt
 ```
 
-FunClip 的 Fun-ASR-Nano、SenseVoice 与字幕兼容路径需要 `funasr>=1.3.25`。如果你之前已经安装过 FunClip，请先执行 `pip install -U "funasr>=1.3.25"`，再启动 Gradio 服务。
+FunClip 的 Fun-ASR-Nano、SenseVoice 与字幕兼容路径需要 `funasr>=1.3.26`。如果你之前已经安装过 FunClip，请先执行 `pip install -U "funasr>=1.3.26"`，再启动 Gradio 服务。
 
 ### 安装imagemagick（可选）
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 librosa
 soundfile
 scikit-learn>=1.3.2
-funasr>=1.3.25
+funasr>=1.3.26
 transformers>=4.32.0,<5.0
 huggingface_hub>=0.19.3,<1.0
 moviepy==1.0.3

--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -6,7 +6,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_funasr_minimum_version_matches_current_model_paths():
     requirements = (ROOT / "requirements.txt").read_text()
-    assert "funasr>=1.3.25" in requirements
+    assert "funasr>=1.3.26" in requirements
     assert "funasr>=1.1.2" not in requirements
     assert "funasr>=1.3.23" not in requirements
 
@@ -14,7 +14,7 @@ def test_funasr_minimum_version_matches_current_model_paths():
 def test_readmes_explain_upgrade_for_existing_installs():
     for readme in ["README.md", "README_zh.md"]:
         text = (ROOT / readme).read_text()
-        assert 'pip install -U "funasr>=1.3.25"' in text
+        assert 'pip install -U "funasr>=1.3.26"' in text
         assert "funasr>=1.3.23" not in text
 
 


### PR DESCRIPTION
## Summary
- bump FunClip's FunASR install floor to 1.3.26
- keep the README upgrade notes and requirements.txt aligned with the latest PyPI release
- update release-floor regression tests

## Tests
- python3 -m pytest -q tests/test_funasr_requirement.py
- git diff --check