### PR TITLE
Route edge ASR users to GGUF runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ python funclip/launch.py
 | Multilingual ASR with emotion and audio event tags | `python funclip/launch.py -m sensevoice` |
 | English video clipping with the Paraformer English model | `python funclip/launch.py -l en` |
 
+If you only need offline speech transcription on CPU or edge devices and do not need FunClip's video clipping UI, use the FunASR llama.cpp / GGUF runtime instead: [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · [Fun-ASR-Nano-GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [SenseVoiceSmall-GGUF](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF).
+
 then visit ```localhost:7860``` you will get a Gradio service like below and you can use FunClip following the steps:
 
 - Step1: Upload your video file (or try the example videos below)

--- a/README_zh.md
+++ b/README_zh.md
@@ -126,6 +126,8 @@ python funclip/launch.py
 | 使用 SenseVoice 进行多语种识别、情绪识别和音频事件检测 | `python funclip/launch.py -m sensevoice` |
 | 使用 Paraformer 英文模型裁剪英文视频 | `python funclip/launch.py -l en` |
 
+如果你只需要在 CPU 或边缘设备上离线转写语音，而不需要 FunClip 的视频剪辑界面，请优先使用 FunASR llama.cpp / GGUF 运行时：[funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · [Fun-ASR-Nano-GGUF](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF) · [SenseVoiceSmall-GGUF](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF)。
+
 随后在浏览器中访问```localhost:7860```即可看到如下图所示的界面，按如下步骤即可进行视频剪辑
 1. 上传你的视频（或使用下方的视频用例）
 2. （可选）设置热词，设置文件输出路径（保存识别结果、视频等）

--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -18,6 +18,18 @@ def test_readmes_explain_upgrade_for_existing_installs():
         assert "funasr>=1.3.23" not in text
 
 
+def test_readmes_route_edge_asr_users_to_gguf_runtime():
+    required_links = [
+        "https://www.funasr.com/llama-cpp.html",
+        "https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-GGUF",
+        "https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF",
+    ]
+    for readme in ["README.md", "README_zh.md"]:
+        text = (ROOT / readme).read_text()
+        for link in required_links:
+            assert link in text
+
+
 def test_english_readme_avoids_visible_typo_regressions():
     text = (ROOT / "README.md").read_text()
     assert "langage" not in text


### PR DESCRIPTION
## Summary
- add English and Chinese README guidance for users who only need offline CPU/edge ASR instead of the FunClip video clipping UI
- route those users to funasr.com/llama-cpp, Fun-ASR-Nano-GGUF, and SenseVoiceSmall-GGUF
- add regression coverage so the edge ASR routing links stay visible in both READMEs

## Validation
- python3 -m pytest -q tests/test_funasr_requirement.py
- python3 -m py_compile tests/test_funasr_requirement.py
- curl HTTP 200 checks for funasr.com/llama-cpp, Fun-ASR-Nano-GGUF, and SenseVoiceSmall-GGUF
- git diff --check

Note: `tests/test_model_selection.py` was not run in this ops environment because collecting it imports `funclip/launch.py`, which requires the optional Gradio UI dependency that is not installed here.
