### PR TITLE
Add FunClip community templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,52 @@
+---
+name: Bug report
+description: Report a reproducible FunClip failure or incorrect clipping result
+title: "[Bug] "
+labels: ["bug"]
+---
+
+## Summary
+
+Describe the problem in one or two sentences.
+
+## Environment
+
+- FunClip version or commit:
+- FunASR version:
+- Operating system:
+- Python version:
+- Installation method:
+- Browser or Gradio version, if using the web UI:
+- GPU/CPU and CUDA version, if relevant:
+
+## Audio or video input
+
+- File type and duration:
+- Language:
+- Public sample link or a minimal synthetic sample, if possible:
+- ASR model and hotwords:
+- LLM provider/model, if the issue involves semantic clipping:
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+What should happen?
+
+## Actual behavior
+
+What happened instead?
+
+## Logs or traceback
+
+```text
+Paste the full error, command output, or browser console log here.
+```
+
+## Screenshots or clips
+
+Attach screenshots, subtitles, timestamps, or before/after clips when they help explain the issue.

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: FunASR documentation
+    url: https://modelscope.github.io/FunASR/
+    about: Read the upstream ASR toolkit documentation.
+  - name: FunASR GitHub discussions
+    url: https://github.com/modelscope/FunASR/discussions
+    about: Ask broader ASR, deployment, or model-selection questions.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+description: Suggest a FunClip workflow, model, UI, or deployment improvement
+title: "[Feature] "
+labels: ["enhancement"]
+---
+
+## Use case
+
+What are you trying to do with FunClip?
+
+## Proposed behavior
+
+Describe the workflow or API you would like.
+
+## Current workaround
+
+How do you handle this today?
+
+## Input and output examples
+
+- Input audio/video type:
+- Expected transcript, subtitle, clip, or export format:
+- Target language or scenario:
+
+## User impact
+
+Who benefits from this change and how often would they use it?
+
+## Related tools or references
+
+Link related projects, papers, demos, or screenshots if useful.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+- TODO
+
+## User impact
+
+Who benefits from this change, and what FunClip workflow improves?
+
+## Validation
+
+- [ ] I ran the relevant tests or commands:
+- [ ] I checked the affected README/docs links, if changed.
+- [ ] I verified the affected UI, API, ASR, LLM, or clipping path, if changed.
+
+## Screenshots or clips
+
+Add before/after screenshots, subtitles, timestamps, or short clips for UI or clipping-result changes.
+
+## Notes for reviewers
+
+Mention any follow-up work, known limitations, or files that deserve extra attention.

--- a/tests/test_github_templates.py
+++ b/tests/test_github_templates.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_issue_templates_collect_funclip_repro_details():
+    template_dir = ROOT / ".github" / "ISSUE_TEMPLATE"
+    required_files = [
+        "bug_report.md",
+        "feature_request.md",
+        "config.yaml",
+    ]
+
+    for name in required_files:
+        assert (template_dir / name).exists()
+
+    bug_text = (template_dir / "bug_report.md").read_text()
+    required_bug_fields = [
+        "FunClip version or commit",
+        "FunASR version",
+        "Operating system",
+        "Python version",
+        "Audio or video input",
+        "Expected behavior",
+        "Actual behavior",
+        "Logs or traceback",
+    ]
+    for field in required_bug_fields:
+        assert field in bug_text
+
+
+def test_pull_request_template_keeps_validation_visible():
+    template = ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
+    assert template.exists()
+
+    text = template.read_text()
+    required = [
+        "Summary",
+        "Validation",
+        "User impact",
+        "Screenshots or clips",
+    ]
+    for marker in required:
+        assert marker in text


### PR DESCRIPTION
## Summary
- add FunClip bug and feature issue templates focused on reproducible clipping, ASR, LLM, and UI reports
- add a PR template that keeps user impact, validation, and screenshots/clips visible
- add regression tests so the community templates do not disappear silently

## Why
FunClip had no GitHub community templates, so maintainers had to ask for environment, input media, ASR/FunASR version, logs, and screenshots after the fact. Better first reports reduce triage time and help new users get unstuck faster.

## Validation
- `python3 -m pytest -q tests/test_github_templates.py tests/test_funasr_requirement.py tests/test_openai_api.py`
- `python3 -m py_compile funclip/launch.py funclip/videoclipper.py funclip/utils/subtitle_utils.py`
- `git diff --cached --check`

Note: `tests/test_litellm_api.py` was not included in the passing set because the ops environment does not have the optional `litellm` package installed; a wider attempt failed only with `ModuleNotFoundError: No module named 'litellm'`.
