### PR TITLE
docs: sync FunASR requirement to 1.3.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ cd FunClip
 pip install -r ./requirements.txt
 ```
 
-FunClip's Fun-ASR-Nano, SenseVoice, and subtitle compatibility paths require `funasr>=1.3.26`. If you installed FunClip before this requirement was updated, run `pip install -U "funasr>=1.3.26"` before starting the Gradio service.
+FunClip's Fun-ASR-Nano, SenseVoice, and subtitle compatibility paths require `funasr>=1.3.27`. If you installed FunClip before this requirement was updated, run `pip install -U "funasr>=1.3.27"` before starting the Gradio service.
 
 ### imagemagick install (Optional)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -75,7 +75,7 @@ cd FunClip
 pip install -r ./requirements.txt
 ```
 
-FunClip 的 Fun-ASR-Nano、SenseVoice 与字幕兼容路径需要 `funasr>=1.3.26`。如果你之前已经安装过 FunClip，请先执行 `pip install -U "funasr>=1.3.26"`，再启动 Gradio 服务。
+FunClip 的 Fun-ASR-Nano、SenseVoice 与字幕兼容路径需要 `funasr>=1.3.27`。如果你之前已经安装过 FunClip，请先执行 `pip install -U "funasr>=1.3.27"`，再启动 Gradio 服务。
 
 ### 安装imagemagick（可选）
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 librosa
 soundfile
 scikit-learn>=1.3.2
-funasr>=1.3.26
+funasr>=1.3.27
 transformers>=4.32.0,<5.0
 huggingface_hub>=0.19.3,<1.0
 moviepy==1.0.3

--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -6,16 +6,16 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_funasr_minimum_version_matches_current_model_paths():
     requirements = (ROOT / "requirements.txt").read_text()
-    assert "funasr>=1.3.26" in requirements
+    assert "funasr>=1.3.27" in requirements
     assert "funasr>=1.1.2" not in requirements
-    assert "funasr>=1.3.23" not in requirements
+    assert "funasr>=1.3.26" not in requirements
 
 
 def test_readmes_explain_upgrade_for_existing_installs():
     for readme in ["README.md", "README_zh.md"]:
         text = (ROOT / readme).read_text()
-        assert 'pip install -U "funasr>=1.3.26"' in text
-        assert "funasr>=1.3.23" not in text
+        assert 'pip install -U "funasr>=1.3.27"' in text
+        assert "funasr>=1.3.26" not in text
 
 
 def test_readmes_route_edge_asr_users_to_gguf_runtime():


### PR DESCRIPTION
## Summary
- raise the FunASR runtime floor from 1.3.26 to the current 1.3.27 release
- update English and Chinese upgrade commands
- keep the release-floor regression guard current

This matches the public FunClip Space, which is already running FunASR 1.3.27 at commit a99af1a3cf95c882baabe143c5c53bae9f89abaa.

## Validation
- python -m pytest -q tests/test_funasr_requirement.py tests/test_github_templates.py tests/test_openai_api.py (10 passed)
- python -m py_compile funclip/launch.py funclip/videoclipper.py funclip/utils/subtitle_utils.py
- git diff --check