### PR TITLE
docs: sync FunASR requirement to 1.3.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ cd FunClip
 pip install -r ./requirements.txt
 ```
 
-FunClip's Fun-ASR-Nano, SenseVoice, and subtitle compatibility paths require `funasr>=1.3.27`. If you installed FunClip before this requirement was updated, run `pip install -U "funasr>=1.3.27"` before starting the Gradio service.
+FunClip's Fun-ASR-Nano, SenseVoice, and subtitle compatibility paths require `funasr>=1.3.28`. This release preserves stable final text after VAD-locked regressions and decodes short trailing speech on `STOP`, improving the final subtitle segment. If you installed FunClip before this requirement was updated, run `pip install -U "funasr>=1.3.28"` before starting the Gradio service. [Release notes](https://github.com/modelscope/FunASR/releases/tag/v1.3.28) · [subtitle guide](https://www.funasr.com/en/blog/funasr-v1-3-28-realtime-websocket-subtitles.html)
 
 ### imagemagick install (Optional)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -75,7 +75,7 @@ cd FunClip
 pip install -r ./requirements.txt
 ```
 
-FunClip 的 Fun-ASR-Nano、SenseVoice 与字幕兼容路径需要 `funasr>=1.3.27`。如果你之前已经安装过 FunClip，请先执行 `pip install -U "funasr>=1.3.27"`，再启动 Gradio 服务。
+FunClip 的 Fun-ASR-Nano、SenseVoice 与字幕兼容路径需要 `funasr>=1.3.28`。该版本会在 VAD 锁定后的最终解码发生退化时保留稳定文本，并在收到 `STOP` 后解码短尾语音，改善最后一段字幕。如果你之前已经安装过 FunClip，请先执行 `pip install -U "funasr>=1.3.28"`，再启动 Gradio 服务。[发布说明](https://github.com/modelscope/FunASR/releases/tag/v1.3.28) · [字幕指南](https://www.funasr.com/blog/funasr-v1-3-28-realtime-websocket-subtitles.html)
 
 ### 安装imagemagick（可选）
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 librosa
 soundfile
 scikit-learn>=1.3.2
-funasr>=1.3.27
+funasr>=1.3.28
 transformers>=4.32.0,<5.0
 huggingface_hub>=0.19.3,<1.0
 moviepy==1.0.3


### PR DESCRIPTION
Raise FunClip’s FunASR minimum to 1.3.28 and explain the realtime final-subtitle fixes in both READMEs. This keeps installation guidance aligned with the current PyPI release and the FunClip Space.\n\nValidation: requirements parsed with `packaging.requirements.Requirement`, release/guide/PyPI URLs returned HTTP 200, and `git diff --check`.