### PR TITLE
docs: use QwenAudio canonical repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ FunClip is part of the **FunAudioLLM** family:
 | Project | Description | Stars |
 |---------|-------------|-------|
 | [FunASR](https://github.com/modelscope/FunASR) | Industrial speech recognition toolkit — VAD, ASR, punctuation, diarization | [![](https://img.shields.io/github/stars/modelscope/FunASR?style=social)](https://github.com/modelscope/FunASR) |
-| [Fun-ASR-Nano](https://github.com/FunAudioLLM/Fun-ASR) | End-to-end LLM-based ASR — flagship and separate 31-language MLT checkpoints, streaming, hotwords ([HF model](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512)) | [![](https://img.shields.io/github/stars/FunAudioLLM/Fun-ASR?style=social)](https://github.com/FunAudioLLM/Fun-ASR) |
-| [SenseVoice](https://github.com/FunAudioLLM/SenseVoice) | Multilingual speech understanding — ASR + emotion + audio events ([HF model](https://huggingface.co/FunAudioLLM/SenseVoiceSmall)) | [![](https://img.shields.io/github/stars/FunAudioLLM/SenseVoice?style=social)](https://github.com/FunAudioLLM/SenseVoice) |
-| [CosyVoice](https://github.com/FunAudioLLM/CosyVoice) | Natural speech generation — multi-language, zero-shot cloning | [![](https://img.shields.io/github/stars/FunAudioLLM/CosyVoice?style=social)](https://github.com/FunAudioLLM/CosyVoice) |
+| [Fun-ASR-Nano](https://github.com/QwenAudio/Fun-ASR) | End-to-end LLM-based ASR — flagship and separate 31-language MLT checkpoints, streaming, hotwords ([HF model](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512)) | [![](https://img.shields.io/github/stars/QwenAudio/Fun-ASR?style=social)](https://github.com/QwenAudio/Fun-ASR) |
+| [SenseVoice](https://github.com/QwenAudio/SenseVoice) | Multilingual speech understanding — ASR + emotion + audio events ([HF model](https://huggingface.co/FunAudioLLM/SenseVoiceSmall)) | [![](https://img.shields.io/github/stars/QwenAudio/SenseVoice?style=social)](https://github.com/QwenAudio/SenseVoice) |
+| [CosyVoice](https://github.com/QwenAudio/CosyVoice) | Natural speech generation — multi-language, zero-shot cloning | [![](https://img.shields.io/github/stars/QwenAudio/CosyVoice?style=social)](https://github.com/QwenAudio/CosyVoice) |
 
 📚FunASR Paper: <a href="https://arxiv.org/abs/2305.11013"><img src="https://img.shields.io/badge/Arxiv-2305.11013-orange"></a> 
 📚SeACo-Paraformer Paper: <a href="https://arxiv.org/abs/2308.03266"><img src="https://img.shields.io/badge/Arxiv-2308.03266-orange"></a>

--- a/funclip/introduction.py
+++ b/funclip/introduction.py
@@ -6,7 +6,7 @@ top_md_1 = ("""
     </div>
     </div>
     
-    基于阿里巴巴通义实验室自研并开源的[FunASR](https://github.com/modelscope/FunASR)工具包及Paraformer、[Fun-ASR-Nano](https://github.com/FunAudioLLM/Fun-ASR)、[SenseVoice](https://github.com/FunAudioLLM/SenseVoice)系列模型及语音识别、端点检测、标点预测、时间戳预测、说话人区分、热词定制化开源链路
+    基于阿里巴巴通义实验室自研并开源的[FunASR](https://github.com/modelscope/FunASR)工具包及Paraformer、[Fun-ASR-Nano](https://github.com/QwenAudio/Fun-ASR)、[SenseVoice](https://github.com/QwenAudio/SenseVoice)系列模型及语音识别、端点检测、标点预测、时间戳预测、说话人区分、热词定制化开源链路
 
     准确识别，自由复制所需段落，或者设置说话人标识，一键裁剪、添加字幕
 

--- a/tests/test_canonical_qwenaudio_links.py
+++ b/tests/test_canonical_qwenaudio_links.py
@@ -1,0 +1,74 @@
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LEGACY_GITHUB_REPO = re.compile(
+    r"FunAudioLLM/(?:CosyVoice|Fun-ASR|SenseVoice)(?![A-Za-z0-9_-])"
+)
+LEGACY_GITHUB_OWNER_URL = re.compile(
+    r"https://(?:github\.com|img\.shields\.io/github/stars)/FunAudioLLM/"
+)
+HUGGING_FACE_URL = re.compile(
+    r"https://huggingface\.co/(?:spaces/)?FunAudioLLM/[^\s)>'\"]+"
+)
+
+
+def _tracked_text_files():
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    )
+    for raw_path in result.stdout.split(b"\0"):
+        if not raw_path:
+            continue
+        path = ROOT / raw_path.decode()
+        try:
+            yield path, path.read_text(encoding="utf-8")
+        except (FileNotFoundError, UnicodeDecodeError, IsADirectoryError):
+            continue
+
+
+def test_legacy_owner_matcher_covers_repository_api_and_charts():
+    legacy_examples = (
+        "https://api.github.com/repos/FunAudioLLM/CosyVoice",
+        "https://api.star-history.com/svg?repos=FunAudioLLM/CosyVoice&type=Date",
+        "https://github.com/FunAudioLLM/CosyVoice",
+        "https://img.shields.io/github/stars/FunAudioLLM/CosyVoice",
+        "FunAudioLLM/Fun-ASR",
+        "FunAudioLLM/SenseVoice",
+    )
+    for text in legacy_examples:
+        without_hugging_face_urls = HUGGING_FACE_URL.sub("", text)
+        assert LEGACY_GITHUB_OWNER_URL.search(text) or LEGACY_GITHUB_REPO.search(
+            without_hugging_face_urls
+        )
+
+    allowed_examples = (
+        "https://huggingface.co/FunAudioLLM/CosyVoice",
+        "https://huggingface.co/spaces/FunAudioLLM/SenseVoice",
+        "FunAudioLLM/CosyVoice-300M",
+        "FunAudioLLM/Fun-ASR-Nano-2512",
+        "FunAudioLLM/SenseVoiceSmall",
+    )
+    for text in allowed_examples:
+        without_hugging_face_urls = HUGGING_FACE_URL.sub("", text)
+        assert not LEGACY_GITHUB_OWNER_URL.search(text)
+        assert not LEGACY_GITHUB_REPO.search(without_hugging_face_urls)
+
+
+def test_tracked_files_use_qwenaudio_for_canonical_github_repositories():
+    offenders = []
+    for path, text in _tracked_text_files():
+        if path.resolve() == Path(__file__).resolve():
+            continue
+        without_hugging_face_urls = HUGGING_FACE_URL.sub("", text)
+        if LEGACY_GITHUB_OWNER_URL.search(text) or LEGACY_GITHUB_REPO.search(
+            without_hugging_face_urls
+        ):
+            offenders.append(str(path.relative_to(ROOT)))
+
+    assert not offenders, "legacy GitHub repository owner in: " + ", ".join(offenders)

--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -6,16 +6,18 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_funasr_minimum_version_matches_current_model_paths():
     requirements = (ROOT / "requirements.txt").read_text()
-    assert "funasr>=1.3.27" in requirements
+    assert "funasr>=1.3.28" in requirements
     assert "funasr>=1.1.2" not in requirements
     assert "funasr>=1.3.26" not in requirements
+    assert "funasr>=1.3.27" not in requirements
 
 
 def test_readmes_explain_upgrade_for_existing_installs():
     for readme in ["README.md", "README_zh.md"]:
         text = (ROOT / readme).read_text()
-        assert 'pip install -U "funasr>=1.3.27"' in text
+        assert 'pip install -U "funasr>=1.3.28"' in text
         assert "funasr>=1.3.26" not in text
+        assert "funasr>=1.3.27" not in text
 
 
 def test_readmes_route_edge_asr_users_to_gguf_runtime():


### PR DESCRIPTION
## Summary

- update Fun-ASR, SenseVoice, and CosyVoice links and star badges to the canonical `QwenAudio` GitHub owner
- preserve Hugging Face `FunAudioLLM/*` model identifiers
- add a tracked-file regression guard for the GitHub owner migration
- refresh the stale FunASR dependency test from 1.3.27 to the already published `funasr>=1.3.28` requirement and bilingual upgrade guidance

## Validation

- focused docs/version/link suite: `9 passed`
- full repository suite: `44 passed, 1 skipped` in an isolated venv with the declared dependencies plus the existing LiteLLM test dependency
- repository scan found zero legacy GitHub owner URLs while retaining 16 Hugging Face namespace URLs
- `git diff --check`
