### PR TITLE
chore: require FunASR 1.3.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ cd FunClip
 pip install -r ./requirements.txt
 ```
 
-FunClip's Fun-ASR-Nano, SenseVoice, and subtitle compatibility paths require `funasr>=1.3.28`. This release preserves stable final text after VAD-locked regressions and decodes short trailing speech on `STOP`, improving the final subtitle segment. If you installed FunClip before this requirement was updated, run `pip install -U "funasr>=1.3.28"` before starting the Gradio service. [Release notes](https://github.com/modelscope/FunASR/releases/tag/v1.3.28) · [subtitle guide](https://www.funasr.com/en/blog/funasr-v1-3-28-realtime-websocket-subtitles.html)
+FunClip's Fun-ASR-Nano, SenseVoice, and subtitle compatibility paths require `funasr>=1.3.29`. This release returns every SenseVoice VAD region through `sentence_info` when token timestamps are unavailable, so clipping and subtitle clients receive segment boundaries instead of an empty timeline. It also includes the real-time final-text and short-tail fixes from 1.3.28. If you installed FunClip before this requirement was updated, run `pip install -U "funasr>=1.3.29"` before starting the Gradio service. [Release notes](https://github.com/modelscope/FunASR/releases/tag/v1.3.29) · [PyPI](https://pypi.org/project/funasr/1.3.29/)
 
 ### imagemagick install (Optional)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -75,7 +75,7 @@ cd FunClip
 pip install -r ./requirements.txt
 ```
 
-FunClip 的 Fun-ASR-Nano、SenseVoice 与字幕兼容路径需要 `funasr>=1.3.28`。该版本会在 VAD 锁定后的最终解码发生退化时保留稳定文本，并在收到 `STOP` 后解码短尾语音，改善最后一段字幕。如果你之前已经安装过 FunClip，请先执行 `pip install -U "funasr>=1.3.28"`，再启动 Gradio 服务。[发布说明](https://github.com/modelscope/FunASR/releases/tag/v1.3.28) · [字幕指南](https://www.funasr.com/blog/funasr-v1-3-28-realtime-websocket-subtitles.html)
+FunClip 的 Fun-ASR-Nano、SenseVoice 与字幕兼容路径需要 `funasr>=1.3.29`。当 SenseVoice 没有 token 时间戳时，该版本会通过 `sentence_info` 返回每个 VAD 语音区域，让智能剪辑与字幕客户端获得分段边界，而不再收到空时间线；同时包含 1.3.28 的实时最终文本和短尾语音修复。如果你之前已经安装过 FunClip，请先执行 `pip install -U "funasr>=1.3.29"`，再启动 Gradio 服务。[发布说明](https://github.com/modelscope/FunASR/releases/tag/v1.3.29) · [PyPI](https://pypi.org/project/funasr/1.3.29/)
 
 ### 安装imagemagick（可选）
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 librosa
 soundfile
 scikit-learn>=1.3.2
-funasr>=1.3.28
+funasr>=1.3.29
 transformers>=4.32.0,<5.0
 huggingface_hub>=0.19.3,<1.0
 moviepy==1.0.3

--- a/tests/test_funasr_requirement.py
+++ b/tests/test_funasr_requirement.py
@@ -6,18 +6,22 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_funasr_minimum_version_matches_current_model_paths():
     requirements = (ROOT / "requirements.txt").read_text()
-    assert "funasr>=1.3.28" in requirements
+    assert "funasr>=1.3.29" in requirements
     assert "funasr>=1.1.2" not in requirements
     assert "funasr>=1.3.26" not in requirements
     assert "funasr>=1.3.27" not in requirements
+    assert "funasr>=1.3.28" not in requirements
 
 
 def test_readmes_explain_upgrade_for_existing_installs():
     for readme in ["README.md", "README_zh.md"]:
         text = (ROOT / readme).read_text()
-        assert 'pip install -U "funasr>=1.3.28"' in text
+        assert 'pip install -U "funasr>=1.3.29"' in text
         assert "funasr>=1.3.26" not in text
         assert "funasr>=1.3.27" not in text
+        assert "funasr>=1.3.28" not in text
+        assert "sentence_info" in text
+        assert "https://github.com/modelscope/FunASR/releases/tag/v1.3.29" in text
 
 
 def test_readmes_route_edge_asr_users_to_gguf_runtime():


### PR DESCRIPTION
## Summary
- raise the FunASR floor to 1.3.29 for SenseVoice VAD segment timestamps
- update English and Chinese upgrade guidance
- guard the package requirement and release link

## Validation
- focused release, canonical-link, template, and OpenAI API tests (12 passed)
- full collection is environment-blocked by missing optional `moviepy`, `gradio`, `litellm`, and `twelvelabs` dependencies; no product assertion failed before collection
- `git diff --check`