### PR TITLE
docs: add stable FunClip community fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ FunClip was first open-sourced by the FunASR team, and useful PRs are welcome.
 
 You can also scan the following DingTalk group or WeChat group QR code to join the community group for communication.
 
+QR codes can expire. If scanning is unavailable, use [GitHub Discussions](https://github.com/modelscope/FunClip/discussions) for questions, ideas, and community projects.
+
 |                           DingTalk group                            |                     WeChat group                      |
 |:-------------------------------------------------------------------:|:-----------------------------------------------------:|
 | <div align="left"><img src="docs/images/dingding.png" width="250"/> | <img src="docs/images/wechat.png" width="215"/></div> |

--- a/README_zh.md
+++ b/README_zh.md
@@ -183,6 +183,8 @@ python funclip/videoclipper.py --stage 2 \
 
 FunClip开源项目由FunASR社区维护，欢迎加入社区，交流与讨论，以及合作开发等。
 
+群二维码可能过期；如果无法扫码，请通过 [GitHub Discussions](https://github.com/modelscope/FunClip/discussions) 提问、交流想法或分享社区项目。
+
 |                              钉钉群                                |                     微信群                      |
 |:-------------------------------------------------------------------:|:-----------------------------------------------------:|
 | <div align="left"><img src="docs/images/dingding.png" width="250"/> | <img src="docs/images/wechat.png" width="215"/></div> |

--- a/tests/test_community_links.py
+++ b/tests/test_community_links.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DISCUSSIONS_URL = "https://github.com/modelscope/FunClip/discussions"
+
+
+@pytest.mark.parametrize(
+    ("readme", "start", "end"),
+    (
+        ("README.md", '<a name="Community"></a>', "## Ecosystem"),
+        ("README_zh.md", '<a name="社区交流"></a>', "## 通过FunASR"),
+    ),
+)
+def test_community_section_has_stable_discussions_fallback(
+    readme: str, start: str, end: str
+) -> None:
+    text = (ROOT / readme).read_text(encoding="utf-8")
+    section = text.split(start, 1)[1].split(end, 1)[0]
+
+    assert section.count(f"[GitHub Discussions]({DISCUSSIONS_URL})") == 1
+    assert "docs/images/dingding.png" in section
+    assert "docs/images/wechat.png" in section


### PR DESCRIPTION
## Summary
- add GitHub Discussions as a durable fallback when community QR codes expire
- keep the existing DingTalk and WeChat QR codes unchanged
- cover both English and Chinese community sections with a focused contract test

## Validation
- `python3 -m pytest -q tests/test_community_links.py` -> 2 passed
- full isolated environment (`requirements.txt` plus the repository-tested optional `litellm>=1.83.0`) -> 52 passed, 1 skipped
- `git diff --check`
- Discussions endpoint returns HTTP 200