### PR TITLE
Add MiniMax provider route to the LLM dispatcher

### DIFF
--- a/funclip/launch.py
+++ b/funclip/launch.py
@@ -179,10 +179,10 @@ if __name__ == "__main__":
         if model.startswith('qwen'):
             return call_qwen_model(apikey, model, user_content+'\n'+srt_text, system_content)
         if model.startswith('gpt') or model.startswith('moonshot') or model.startswith('deepseek') or model.startswith('atlascloud/') or model.startswith('minimax/'):
-            return openai_call(apikey, model, system_content, user_content+'\n'+srt_text)
+            return openai_call(apikey, model, user_content+'\n'+srt_text, system_content)
         elif model.startswith('g4f'):
             model = "-".join(model.split('-')[1:])
-            return g4f_openai_call(model, system_content, user_content+'\n'+srt_text)
+            return g4f_openai_call(model, user_content+'\n'+srt_text, system_content)
         else:
             logging.error("LLM name error, only {} are supported as LLM name prefix."
                           .format(SUPPORT_LLM_PREFIX))
@@ -282,8 +282,8 @@ if __name__ == "__main__":
                                              "litellm/anthropic/claude-sonnet-4-6",
                                              "atlascloud/qwen/qwen3.5-flash",
                                              "atlascloud/deepseek-ai/deepseek-v4-pro",
-                                             "minimax/MiniMax-M3",
                                              "minimax/MiniMax-M2.7",
+                                             "minimax/MiniMax-M2.7-highspeed",
                                              "pegasus1.5"],
                                     value="deepseek-chat",
                                     label="LLM Model Name",

--- a/funclip/launch.py
+++ b/funclip/launch.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
             )
         
     def llm_inference(system_content, user_content, srt_text, model, apikey, video_input=None):
-        SUPPORT_LLM_PREFIX = ['litellm', 'qwen', 'gpt', 'g4f', 'moonshot', 'deepseek', 'atlascloud', 'pegasus']
+        SUPPORT_LLM_PREFIX = ['litellm', 'qwen', 'gpt', 'g4f', 'moonshot', 'deepseek', 'atlascloud', 'minimax', 'pegasus']
         if model.startswith('litellm/'):
             return litellm_call(apikey, model, user_content+'\n'+srt_text, system_content)
         if model.startswith('pegasus'):
@@ -178,7 +178,7 @@ if __name__ == "__main__":
             return call_twelvelabs_pegasus(apikey, video_input, model=model, prompt=system_content)
         if model.startswith('qwen'):
             return call_qwen_model(apikey, model, user_content+'\n'+srt_text, system_content)
-        if model.startswith('gpt') or model.startswith('moonshot') or model.startswith('deepseek') or model.startswith('atlascloud/'):
+        if model.startswith('gpt') or model.startswith('moonshot') or model.startswith('deepseek') or model.startswith('atlascloud/') or model.startswith('minimax/'):
             return openai_call(apikey, model, system_content, user_content+'\n'+srt_text)
         elif model.startswith('g4f'):
             model = "-".join(model.split('-')[1:])
@@ -282,6 +282,8 @@ if __name__ == "__main__":
                                              "litellm/anthropic/claude-sonnet-4-6",
                                              "atlascloud/qwen/qwen3.5-flash",
                                              "atlascloud/deepseek-ai/deepseek-v4-pro",
+                                             "minimax/MiniMax-M3",
+                                             "minimax/MiniMax-M2.7",
                                              "pegasus1.5"],
                                     value="deepseek-chat",
                                     label="LLM Model Name",

--- a/funclip/llm/openai_api.py
+++ b/funclip/llm/openai_api.py
@@ -5,6 +5,13 @@ from openai import OpenAI
 ATLASCLOUD_API_BASE = "https://api.atlascloud.ai/v1"
 ATLASCLOUD_MODEL_PREFIX = "atlascloud/"
 
+# MiniMax exposes an OpenAI-compatible chat completions endpoint. The global
+# endpoint is used by default; set MINIMAX_API_BASE to the mainland China host
+# (https://api.minimaxi.com/v1) to route requests through the cn_zh region.
+MINIMAX_API_BASE = "https://api.minimax.io/v1"
+MINIMAX_API_BASE_CN = "https://api.minimaxi.com/v1"
+MINIMAX_MODEL_PREFIX = "minimax/"
+
 
 def _resolve_model_config(model):
     base_url = None
@@ -20,6 +27,16 @@ def _resolve_model_config(model):
         if not base_url:
             base_url = ATLASCLOUD_API_BASE
         api_key_env = "ATLASCLOUD_API_KEY"
+    elif model.startswith(MINIMAX_MODEL_PREFIX):
+        model = model[len(MINIMAX_MODEL_PREFIX):]
+        if not model:
+            raise ValueError(
+                "Model name is empty after stripping minimax/ prefix"
+            )
+        base_url = os.environ.get("MINIMAX_API_BASE", MINIMAX_API_BASE).strip()
+        if not base_url:
+            base_url = MINIMAX_API_BASE
+        api_key_env = "MINIMAX_API_KEY"
     elif model.startswith("deepseek"):
         base_url = "https://api.deepseek.com"
     elif model.startswith("gpt-3.5-turbo"):

--- a/funclip/llm/openai_api.py
+++ b/funclip/llm/openai_api.py
@@ -70,7 +70,11 @@ def openai_call(apikey,
                 system_content=None):
     model, base_url, api_key_env = _resolve_model_config(model)
     if not apikey and api_key_env:
-        apikey = os.environ.get(api_key_env)
+        apikey = os.environ.get(api_key_env, "").strip()
+        if not apikey:
+            raise ValueError(
+                f"Missing API key: pass apikey or set {api_key_env}"
+            )
 
     client = OpenAI(
         # This is the default and can be omitted

--- a/tests/test_minimax_api.py
+++ b/tests/test_minimax_api.py
@@ -1,0 +1,76 @@
+"""Tests for MiniMax routing through the OpenAI-compatible client."""
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from funclip.llm.openai_api import (
+    MINIMAX_API_BASE,
+    MINIMAX_API_BASE_CN,
+    openai_call,
+)
+
+
+def _mock_completion(content="ok"):
+    completion = MagicMock()
+    completion.choices = [MagicMock()]
+    completion.choices[0].message.content = content
+    return completion
+
+
+class TestMiniMaxRouting(unittest.TestCase):
+    def test_minimax_prefix_uses_global_base_url(self):
+        client = MagicMock()
+        client.chat.completions.create.return_value = _mock_completion("clip plan")
+
+        with patch("funclip.llm.openai_api.OpenAI", return_value=client) as openai_cls:
+            result = openai_call(
+                "minimax-key",
+                "minimax/MiniMax-M3",
+                "subtitle text",
+                "find highlights",
+            )
+
+        self.assertEqual(result, "clip plan")
+        openai_cls.assert_called_once_with(
+            api_key="minimax-key",
+            base_url=MINIMAX_API_BASE,
+        )
+        call_kwargs = client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs["model"], "MiniMax-M3")
+
+    def test_minimax_api_key_falls_back_to_env(self):
+        client = MagicMock()
+        client.chat.completions.create.return_value = _mock_completion()
+
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-minimax-key"}, clear=False):
+            with patch("funclip.llm.openai_api.OpenAI", return_value=client) as openai_cls:
+                openai_call("", "minimax/MiniMax-M2.7", "text")
+
+        openai_cls.assert_called_once_with(
+            api_key="env-minimax-key",
+            base_url=MINIMAX_API_BASE,
+        )
+        call_kwargs = client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs["model"], "MiniMax-M2.7")
+
+    def test_minimax_api_base_env_overrides_region(self):
+        client = MagicMock()
+        client.chat.completions.create.return_value = _mock_completion()
+
+        with patch.dict(os.environ, {"MINIMAX_API_BASE": MINIMAX_API_BASE_CN}, clear=False):
+            with patch("funclip.llm.openai_api.OpenAI", return_value=client) as openai_cls:
+                openai_call("minimax-key", "minimax/MiniMax-M3", "text")
+
+        openai_cls.assert_called_once_with(
+            api_key="minimax-key",
+            base_url=MINIMAX_API_BASE_CN,
+        )
+
+    def test_empty_minimax_model_raises(self):
+        with self.assertRaises(ValueError):
+            openai_call("key", "minimax/", "text")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_minimax_api.py
+++ b/tests/test_minimax_api.py
@@ -71,6 +71,18 @@ class TestMiniMaxRouting(unittest.TestCase):
         with self.assertRaises(ValueError):
             openai_call("key", "minimax/", "text")
 
+    def test_missing_minimax_key_does_not_fall_back_to_openai_key(self):
+        with patch.dict(
+            os.environ,
+            {"OPENAI_API_KEY": "openai-only-key"},
+            clear=True,
+        ):
+            with patch("funclip.llm.openai_api.OpenAI") as openai_cls:
+                with self.assertRaisesRegex(ValueError, "MINIMAX_API_KEY"):
+                    openai_call("", "minimax/MiniMax-M2.7", "text")
+
+        openai_cls.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_minimax_launch_integration.py
+++ b/tests/test_minimax_launch_integration.py
@@ -1,0 +1,56 @@
+"""Regression tests for MiniMax choices and prompt routing in the launcher."""
+
+import ast
+import unittest
+from pathlib import Path
+
+
+LAUNCH_PATH = Path(__file__).resolve().parents[1] / "funclip" / "launch.py"
+
+
+class TestMiniMaxLaunchIntegration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tree = ast.parse(LAUNCH_PATH.read_text(encoding="utf-8"))
+
+    def test_openai_compatible_route_preserves_prompt_roles(self):
+        llm_inference = next(
+            node
+            for node in ast.walk(self.tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "llm_inference"
+        )
+        openai_call = next(
+            node
+            for node in ast.walk(llm_inference)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "openai_call"
+        )
+
+        self.assertEqual(ast.unparse(openai_call.args[2]), "user_content + '\\n' + srt_text")
+        self.assertEqual(ast.unparse(openai_call.args[3]), "system_content")
+
+        g4f_call = next(
+            node
+            for node in ast.walk(llm_inference)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "g4f_openai_call"
+        )
+        self.assertEqual(ast.unparse(g4f_call.args[1]), "user_content + '\\n' + srt_text")
+        self.assertEqual(ast.unparse(g4f_call.args[2]), "system_content")
+
+    def test_dropdown_only_lists_documented_minimax_models(self):
+        string_literals = {
+            node.value
+            for node in ast.walk(self.tree)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        }
+
+        self.assertIn("minimax/MiniMax-M2.7", string_literals)
+        self.assertIn("minimax/MiniMax-M2.7-highspeed", string_literals)
+        self.assertNotIn("minimax/MiniMax-M3", string_literals)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reason: The executable LLM dispatcher had no MiniMax provider route, so the current MiniMax-M2.7 models could not be selected.

This adds MiniMax as an OpenAI-compatible provider, following the existing prefix-based routing used by other compatible backends.

Changes:
- `funclip/llm/openai_api.py`: resolves the `minimax/` prefix to the official global `https://api.minimax.io/v1` endpoint, supports `MINIMAX_API_BASE` for the mainland China endpoint, and falls back only to `MINIMAX_API_KEY` when no key is passed. A missing provider key now fails before the OpenAI SDK can fall back to `OPENAI_API_KEY`.
- `funclip/launch.py`: registers the provider, offers the currently documented `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` models, and preserves the intended user/system prompt roles for OpenAI-compatible and g4f routes.
- Tests cover prefix stripping, endpoint selection, region override, provider-key isolation, empty model handling, documented model choices, and prompt-role routing.

Validation:
- `python -m pytest tests -q`: **59 passed, 1 skipped**
- `python -m compileall -q funclip tests`
- `git diff --check`

The maintainer follow-up commit is SSH-signed and includes DCO.
