### PR TITLE
Fix case-insensitive clip matching and zero-match output

### DIFF
--- a/funclip/utils/trans_utils.py
+++ b/funclip/utils/trans_utils.py
@@ -8,6 +8,9 @@ import re
 import numpy as np  
 
 PUNC_LIST = ['，', '。', '！', '？', '、', ',', '.', '?', '!']
+ASCII_LOWER_TABLE = str.maketrans(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz"
+)
 
 def pre_proc(text):
     res = ''
@@ -28,14 +31,18 @@ def pre_proc(text):
 def proc(raw_text, timestamp, dest_text, lang='zh'):
     # simple matching
     ld = len(dest_text.split())
+    normalized_raw_text = raw_text.translate(ASCII_LOWER_TABLE)
+    normalized_dest_text = dest_text.translate(ASCII_LOWER_TABLE)
     mi, ts = [], []
     offset = 0
     while True:
-        fi = raw_text.find(dest_text, offset, len(raw_text))
+        fi = normalized_raw_text.find(
+            normalized_dest_text, offset, len(normalized_raw_text)
+        )
         ti = raw_text[:fi].count(' ')
         if fi == -1:
             break
-        offset = fi + ld
+        offset = fi + len(normalized_dest_text)
         mi.append(fi)
         ts.append([timestamp[ti][0]*16, timestamp[ti+ld-1][1]*16])
     return ts

--- a/funclip/videoclipper.py
+++ b/funclip/videoclipper.py
@@ -306,7 +306,7 @@ class VideoClipper():
                         offset_b, offset_e = 0, 0
                     # import pdb; pdb.set_trace()
                     _dest_text = pre_proc(_dest_text)
-                    ts = proc(recog_res_raw, timestamp, _dest_text.lower())
+                    ts = proc(recog_res_raw, timestamp, _dest_text)
                     for _ts in ts: all_ts.append([_ts[0]+offset_b*16, _ts[1]+offset_e*16])
                     if len(ts) > 1 and offset_match:
                         warning_messages.append(
@@ -382,8 +382,9 @@ class VideoClipper():
             video_clip.write_videofile(clip_video_file, audio_codec="aac", temp_audiofile=temp_audio_file)
             self.GLOBAL_COUNT += 1
         else:
-            clip_video_file = video_filename
-            message = "No period found in the audio, return raw speech. You may check the recognition result and try other destination text." + log_append
+            clip_video_file = None
+            message = "No period found in the video; no output was generated. You may check the recognition result and try other destination text." + log_append
+            logging.warning(message)
             srt_clip = ''
         return clip_video_file, message, clip_srt
 

--- a/tests/test_duplicate_text_matching.py
+++ b/tests/test_duplicate_text_matching.py
@@ -86,6 +86,49 @@ class TestDuplicateTextMatching(unittest.TestCase):
         self.assertEqual(len(output_clip.write_calls), 1)
         self.assertIn("2 periods found", message)
 
+    @patch(
+        "videoclipper.generate_srt_clip",
+        return_value=("", [((0.0, 0.2), "HELLO WORLD")], 1),
+    )
+    def test_video_clip_matches_ascii_case_insensitively(self, _generate_srt):
+        clipper = VideoClipper(None)
+        clipper.lang = "en"
+        video = DummyVideo()
+        state = {
+            "recog_res_raw": "HELLO WORLD",
+            "timestamp": [[0, 100], [100, 200]],
+            "sentences": [],
+            "video": video,
+            "clip_video_file": "/tmp/case_clip.mp4",
+            "video_filename": "/tmp/case.mp4",
+        }
+
+        output_path, message, _ = clipper.video_clip("hello world", 0, 0, state)
+
+        self.assertIsNotNone(output_path)
+        self.assertEqual(video.subclip_calls, [(0.0, 0.2)])
+        self.assertIn("1 periods found", message)
+
+    def test_video_clip_returns_no_output_when_text_does_not_match(self):
+        clipper = VideoClipper(None)
+        clipper.lang = "en"
+        video = DummyVideo()
+        state = {
+            "recog_res_raw": "HELLO WORLD",
+            "timestamp": [[0, 100], [100, 200]],
+            "sentences": [],
+            "video": video,
+            "clip_video_file": "/tmp/no_match_clip.mp4",
+            "video_filename": "/tmp/no_match.mp4",
+        }
+
+        output_path, message, subtitle = clipper.video_clip("missing", 0, 0, state)
+
+        self.assertIsNone(output_path)
+        self.assertEqual(video.subclip_calls, [])
+        self.assertEqual(subtitle, "")
+        self.assertIn("No period found", message)
+
     @patch("videoclipper.generate_srt_clip", return_value=("", [], 0))
     def test_audio_clip_formats_offset_warning_for_repeated_matches(
         self, _generate_srt


### PR DESCRIPTION
## Summary

- match ASCII letters case-insensitively while preserving character-to-timestamp indexes
- use the same matching behavior for audio and video clipping
- return no video output and emit a warning when destination text has no match
- cover uppercase recognition output, zero-match behavior, and existing duplicate matching

## Verification

- `python -m pytest -q tests/test_duplicate_text_matching.py` (`7 passed`)
- `python -m pytest -q tests` in an isolated environment with the repository's optional providers (`61 passed, 1 skipped`)
- `git diff --check`

Closes #198
