### PR TITLE
Add MiniMax-M3 to the LLM model dropdown

### DIFF
--- a/funclip/launch.py
+++ b/funclip/launch.py
@@ -279,6 +279,7 @@ if __name__ == "__main__":
                                              "litellm/anthropic/claude-sonnet-4-6",
                                              "atlascloud/qwen/qwen3.5-flash",
                                              "atlascloud/deepseek-ai/deepseek-v4-pro",
+                                             "minimax/MiniMax-M3",
                                              "minimax/MiniMax-M2.7",
                                              "minimax/MiniMax-M2.7-highspeed",
                                              "pegasus1.5"],

--- a/tests/test_minimax_launch_integration.py
+++ b/tests/test_minimax_launch_integration.py
@@ -47,9 +47,9 @@ class TestMiniMaxLaunchIntegration(unittest.TestCase):
             if isinstance(node, ast.Constant) and isinstance(node.value, str)
         }
 
+        self.assertIn("minimax/MiniMax-M3", string_literals)
         self.assertIn("minimax/MiniMax-M2.7", string_literals)
         self.assertIn("minimax/MiniMax-M2.7-highspeed", string_literals)
-        self.assertNotIn("minimax/MiniMax-M3", string_literals)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reason: The executable MiniMax model dropdown listed only the MiniMax-M2.7 entries and omitted MiniMax-M3, so that model could not be picked in the LLM clipping UI.

## Changes

- `funclip/launch.py`: add `minimax/MiniMax-M3` to the `llm_model` dropdown choices, next to the existing MiniMax entries.
- `tests/test_minimax_launch_integration.py`: update the dropdown regression test so the listed MiniMax models are asserted to include `minimax/MiniMax-M3`.

No routing changes were required. `funclip/llm/openai_api.py` already strips the `minimax/` prefix and resolves any MiniMax model to the OpenAI-compatible endpoint (`https://api.minimax.io/v1` by default, with `MINIMAX_API_BASE` available for the regional host and `MINIMAX_API_KEY` for credentials), and `llm_inference` in `funclip/launch.py` already dispatches the `minimax/` prefix through `openai_call`. The dropdown entry was the only missing piece.

## Checks

- `python -m pytest -q tests/test_minimax_launch_integration.py tests/test_minimax_api.py tests/test_openai_api.py` — 10 passed.
- `python -m pytest -q tests/ --ignore=tests/test_duplicate_text_matching.py --ignore=tests/test_model_selection.py --ignore=tests/test_recognition_result_compat.py` — 47 passed, 1 skipped, 6 failed. All 6 failures are `ModuleNotFoundError` for `gradio` and `twelvelabs`, which are not installed in this sandbox; the same 6 tests fail identically on the base commit, so they are unrelated to this change. The three ignored modules fail to import for the same reason (`gradio`, `moviepy`).
- `python -m compileall funclip/launch.py tests/test_minimax_launch_integration.py`
